### PR TITLE
ci: add lychee link-checker for main repo + wiki

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -1,0 +1,53 @@
+name: Link check
+
+# Checks links across the main repo AND the separate wiki repo.
+# The wiki is a different git repo with no actions surface of its
+# own, so we pull it into this run and run lychee over everything.
+#
+# Runs weekly and on manual dispatch. Also on PRs that touch any
+# markdown file in the main repo.
+
+on:
+  schedule:
+    - cron: '0 5 * * 1'  # Mondays at 05:00 UTC
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - '**/*.md'
+
+permissions:
+  contents: read
+  issues: write  # lychee can open an issue on failure
+
+jobs:
+  lychee:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main repo
+        uses: actions/checkout@v4
+
+      - name: Checkout wiki
+        uses: actions/checkout@v4
+        with:
+          repository: simons-plugins/domio-smart-home-support.wiki
+          path: wiki
+          # Wiki cloning doesn't need a token for public repos.
+
+      - name: Link Checker
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: >-
+            --no-progress
+            --max-concurrency 4
+            --exclude-mail
+            './**/*.md'
+            './**/*.html'
+          fail: true
+          output: ./lychee/out.md
+
+      - name: Upload report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: lychee-report
+          path: ./lychee/out.md


### PR DESCRIPTION
## Summary

The support wiki lives in a separate git repo with no Actions surface of its own. Broken links there (e.g. the recently-fixed \`Variables.md → Set-Variable-via-Shortcuts\` deadlink) can sit indefinitely. This workflow clones the wiki into each run and runs lychee across both trees.

- **Weekly schedule** (Mondays 05:00 UTC) — catches drift even without PR activity
- **workflow_dispatch** — manual runs
- **PR trigger** on any markdown change in the main repo
- Failures upload the lychee report as an artifact

## Test plan

- [ ] Trigger the workflow manually via Actions tab → expect pass (wiki was just fixed)
- [ ] Temporarily introduce a bad link, push, verify PR check fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated link validation for documentation. The system now periodically checks for broken links in markdown and wiki documentation, generating reports when issues are detected to ensure documentation quality and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->